### PR TITLE
Temporarily fix jupyter with tornado 6.0 issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux; \
     #
     # Jupyter
     #
-    python3 -m pip install --no-cache-dir jupyter toree; \
+    python3 -m pip install --no-cache-dir jupyter "tornado<6" toree; \
     jupyter --version; \
     # Set the right Python version for Spark worker under PySpark
     apt-get install -y --no-install-recommends jq; \


### PR DESCRIPTION
See #6. This doesn't resolve it, but just a workaround until a proper > Tornado 6.0 patch is created for Python 3.5.